### PR TITLE
squid:S3052 - Fields should not be initialized to default values

### DIFF
--- a/app/src/main/java/com/red5pro/red5proexamples/examples/BaseExample.java
+++ b/app/src/main/java/com/red5pro/red5proexamples/examples/BaseExample.java
@@ -24,7 +24,7 @@ public class BaseExample extends Fragment {
     protected R5Stream subscribe;
     protected R5Stream publish;
 
-    public static boolean swapped = false;
+    public static boolean swapped;
 
     protected String getStream1(){
         if(!swapped) return getString(R.string.stream1);
@@ -69,7 +69,7 @@ public class BaseExample extends Fragment {
     }
 
     protected Camera openFrontFacingCameraGingerbread() {
-        int cameraCount = 0;
+        int cameraCount;
         Camera cam = null;
         Camera.CameraInfo cameraInfo = new Camera.CameraInfo();
         cameraCount = Camera.getNumberOfCameras();

--- a/app/src/main/java/com/red5pro/red5proexamples/examples/clustering/ClusterSubscriber.java
+++ b/app/src/main/java/com/red5pro/red5proexamples/examples/clustering/ClusterSubscriber.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  * Created by Andy Shaules on 11/23/2015.
  */
 public class ClusterSubscriber extends BaseExample {
-    R5Configuration config =null;
+    R5Configuration config;
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
 

--- a/app/src/main/java/com/red5pro/red5proexamples/examples/custompublish/CustomCaptureDevice.java
+++ b/app/src/main/java/com/red5pro/red5proexamples/examples/custompublish/CustomCaptureDevice.java
@@ -25,10 +25,10 @@ public class CustomCaptureDevice extends R5VideoSource {
     byte bufferOut[] ;
     private Runnable engine;
     private volatile boolean doEncode=true;
-    private long streamTime = 0;
+    private long streamTime;
     private Bitmap bitmap;
     int[] pixels = new int[320 * 240];
-    boolean change = false;
+    boolean change;
 
 
     @Override

--- a/app/src/main/java/com/red5pro/red5proexamples/examples/twoway/TwoWayExample.java
+++ b/app/src/main/java/com/red5pro/red5proexamples/examples/twoway/TwoWayExample.java
@@ -25,7 +25,7 @@ import org.json.JSONArray;
 public class TwoWayExample extends BaseExample implements R5ConnectionListener {
 
     Thread listThread;
-    boolean hasPublished = false;
+    boolean hasPublished;
 
     public TwoWayExample() {
         // Required empty public constructor


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S3052 - Fields should not be initialized to default values

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat
