### PR TITLE
Reconciliation of R5AudioController creation and sampleRate setting

### DIFF
--- a/app/src/main/java/red5pro/org/testandroidproject/tests/SharedObjectTest/SharedObjectTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/SharedObjectTest/SharedObjectTest.java
@@ -96,6 +96,7 @@ public class SharedObjectTest extends PublishTest{
         //setup a new stream using the connection
         stream = new R5Stream(connection);
 
+        stream.audioController = new R5AudioController();
         stream.audioController.sampleRate = TestContent.GetPropertyInt("sample_rate");
 
         stream.client = this;
@@ -108,8 +109,6 @@ public class SharedObjectTest extends PublishTest{
         preview.attachStream(stream);
 
         preview.showDebugView(TestContent.GetPropertyBool("debug_view"));
-
-        stream.audioController = new R5AudioController();
 
         stream.play(TestContent.GetPropertyString("stream1"));
     }

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeAuthTest/SubscribeAuthTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeAuthTest/SubscribeAuthTest.java
@@ -35,6 +35,7 @@ public class SubscribeAuthTest extends SubscribeTest {
         //setup a new stream using the connection
         subscribe = new R5Stream(connection);
 
+        subscribe.audioController = new R5AudioController();
         subscribe.audioController.sampleRate = TestContent.GetPropertyInt("sample_rate");
 
         subscribe.client = this;
@@ -47,8 +48,6 @@ public class SubscribeAuthTest extends SubscribeTest {
         display.attachStream(subscribe);
 
         display.showDebugView(TestContent.GetPropertyBool("debug_view"));
-
-        subscribe.audioController = new R5AudioController();
 
         subscribe.play(TestContent.GetPropertyString("stream1"));
 

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeCluster/SubscribeCluster.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeCluster/SubscribeCluster.java
@@ -15,6 +15,7 @@ import com.red5pro.streaming.R5Connection;
 import com.red5pro.streaming.R5Stream;
 import com.red5pro.streaming.R5StreamProtocol;
 import com.red5pro.streaming.config.R5Configuration;
+import com.red5pro.streaming.media.R5AudioController;
 import com.red5pro.streaming.view.R5VideoView;
 
 import org.apache.http.HttpResponse;
@@ -101,6 +102,9 @@ public class SubscribeCluster extends SubscribeTest {
         //setup a new stream using the connection
         subscribe = new R5Stream(connection);
         subscribe.setListener(this);
+
+        subscribe.audioController = new R5AudioController();
+        subscribe.audioController.sampleRate = TestContent.GetPropertyInt("sample_rate");
 
         //show all logging
         subscribe.setLogLevel(R5Stream.LOG_LEVEL_DEBUG);

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeNoViewTest/SubscribeNoViewTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeNoViewTest/SubscribeNoViewTest.java
@@ -16,6 +16,7 @@ import com.red5pro.streaming.R5StreamProtocol;
 import com.red5pro.streaming.config.R5Configuration;
 import com.red5pro.streaming.event.R5ConnectionEvent;
 import com.red5pro.streaming.event.R5ConnectionListener;
+import com.red5pro.streaming.media.R5AudioController;
 
 import red5pro.org.testandroidproject.TestDetailFragment;
 import red5pro.org.testandroidproject.tests.PublishSendTest.PublishSendTest;
@@ -71,6 +72,9 @@ public class SubscribeNoViewTest extends TestDetailFragment implements R5Connect
         //setup a new stream using the connection
         subscribe = new R5Stream(connection);
         subscribe.setListener(this);
+
+        subscribe.audioController = new R5AudioController();
+        subscribe.audioController.sampleRate = TestContent.GetPropertyInt("sample_rate");
 
         //show all logging
         subscribe.setLogLevel(R5Stream.LOG_LEVEL_DEBUG);

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeStreamManagerTest/SubscribeStreamManagerTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeStreamManagerTest/SubscribeStreamManagerTest.java
@@ -13,6 +13,7 @@ import com.red5pro.streaming.R5Connection;
 import com.red5pro.streaming.R5Stream;
 import com.red5pro.streaming.R5StreamProtocol;
 import com.red5pro.streaming.config.R5Configuration;
+import com.red5pro.streaming.media.R5AudioController;
 import com.red5pro.streaming.view.R5VideoView;
 
 import org.apache.http.HttpResponse;
@@ -109,6 +110,9 @@ public class SubscribeStreamManagerTest extends SubscribeTest {
         //setup a new stream using the connection
         subscribe = new R5Stream(connection);
         subscribe.setListener(this);
+
+        subscribe.audioController = new R5AudioController();
+        subscribe.audioController.sampleRate = TestContent.GetPropertyInt("sample_rate");
 
         //show all logging
         subscribe.setLogLevel(R5Stream.LOG_LEVEL_DEBUG);

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeTest/SubscribeTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeTest/SubscribeTest.java
@@ -88,6 +88,9 @@ public class SubscribeTest extends TestDetailFragment implements R5ConnectionLis
         //setup a new stream using the connection
         subscribe = new R5Stream(connection);
 
+        //Some devices can't handle rapid reuse of the audio controller, and will crash
+        //Recreation of the controller assures that the example will always be stable
+        subscribe.audioController = new R5AudioController();
         subscribe.audioController.sampleRate = TestContent.GetPropertyInt("sample_rate");
 
         subscribe.client = this;
@@ -100,8 +103,6 @@ public class SubscribeTest extends TestDetailFragment implements R5ConnectionLis
         display.attachStream(subscribe);
 
         display.showDebugView(TestContent.GetPropertyBool("debug_view"));
-
-        subscribe.audioController = new R5AudioController();
 
         subscribe.play(TestContent.GetPropertyString("stream1"));
 

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeTwoStreamTest/SubscribeTwoStreamTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeTwoStreamTest/SubscribeTwoStreamTest.java
@@ -46,6 +46,9 @@ public class SubscribeTwoStreamTest extends SubscribeTest {
         subscribe = new R5Stream(connection);
         subscribe.setListener(this);
 
+        subscribe.audioController = new R5AudioController();
+        subscribe.audioController.sampleRate = TestContent.GetPropertyInt("sample_rate");
+
         //show all logging
         subscribe.setLogLevel(R5Stream.LOG_LEVEL_DEBUG);
 
@@ -93,6 +96,7 @@ public class SubscribeTwoStreamTest extends SubscribeTest {
                             secondDisplay.showDebugView(TestContent.GetPropertyString("debug_view").equals("true"));
 
                             secondSubscribe.audioController = new R5AudioController();
+                            secondSubscribe.audioController.sampleRate = TestContent.GetPropertyInt("sample_rate");
                             secondSubscribe.play(TestContent.GetPropertyString("stream2"));
                         }
                     });

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/TwoWayTest/TwoWayTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/TwoWayTest/TwoWayTest.java
@@ -234,6 +234,8 @@ public class TwoWayTest extends PublishTest {
                 };
                 subscribe.setListener(listener);
 
+                //Unlike basic subscription, two-way needs echo cancellation, which needs the subscriber and publisher
+                //to use the same Audio Controller - instead of recreating it for stability, we delay the subscriber
                 subscribe.play(TestContent.GetPropertyString("stream2"));
 
                 killListThread();


### PR DESCRIPTION
Recreating the audio controller is necesary for some devices when there's a chance that the subscriber will be rapidly created and destroyed.
The sample rate was for some reason set before this recreation.
Added comments to prevent this from being forgotten again later.