### PR TITLE
Determining protocol from `server_port` in network requests.

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,9 +3,6 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <compositeConfiguration>
-          <compositeBuild compositeDefinitionSource="SCRIPT" />
-        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -25,7 +25,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8 (2)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,7 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
-      <module fileurl="file://$PROJECT_DIR$/streaming-android 2.iml" filepath="$PROJECT_DIR$/streaming-android 2.iml" />
+      <module fileurl="file://$PROJECT_DIR$/streaming-android.iml" filepath="$PROJECT_DIR$/streaming-android.iml" />
     </modules>
   </component>
 </project>

--- a/app/app.iml
+++ b/app/app.iml
@@ -17,26 +17,26 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/src/main/res;file://$MODULE_DIR$/build/generated/res/rs/debug;file://$MODULE_DIR$/build/generated/res/resValues/debug" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/src/main/res" />
         <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/src/main/assets" />
       </configuration>
     </facet>
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
-    <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
-    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
+    <output url="file://$MODULE_DIR$/build/intermediates/javac/debug/compileDebugJavaWithJavac/classes" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/javac/debugUnitTest/compileDebugUnitTestJavaWithJavac/classes" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/aidl_source_output_dir/debug/compileDebugAidl/out" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/renderscript_source_output_dir/debug/compileDebugRenderscript/out" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/aidl_source_output_dir/debugAndroidTest/compileDebugAndroidTestAidl/out" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/renderscript_source_output_dir/debugAndroidTest/compileDebugAndroidTestRenderscript/out" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/test/debug" isTestSource="true" generated="true" />
@@ -47,13 +47,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/assets" type="java-test-resource" />
@@ -61,6 +54,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
@@ -68,13 +68,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -82,42 +75,56 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/build/generated/not_namespaced_r_class_sources" />
-      <excludeFolder url="file://$MODULE_DIR$/build/generated/source/r" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotation_processor_list" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/apk_list" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundle_manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/check-manifest" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/check_manifest_result" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/compatible_screen_manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/external_libs_dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant_app_manifest" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant_run_merged_manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaPrecompile" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javac" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint_jar" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/merged_assets" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/merged_manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/metadata_feature_manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/prebuild" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/processed_res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/resources" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shader_assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/signing_config" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/splits-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/reports" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
-      <excludeFolder url="jar://$MODULE_DIR$/build/intermediates/mockable-android-20.jar!/" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 22 Platform (1)" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android API 22 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Gradle: ch.qos.logback:logback-classic:1.1.2@jar" level="project" />
-    <orderEntry type="library" name="Gradle: org.apache.mina:mina-core:2.0.16@jar" level="project" />
-    <orderEntry type="library" name="Gradle: __local_aars__:/Users/davidHeimann/Documents/git/streaming-android 2/app/libs/red5streaming.jar:unspecified@jar" level="project" />
     <orderEntry type="library" name="Gradle: com.android.support:support-annotations:22.2.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: __local_aars__:/Users/toddanderson/Documents/workspace/red5pro/streaming-android/app/libs/red5streaming.jar:unspecified@jar" level="project" />
+    <orderEntry type="library" name="Gradle: org.apache.mina:mina-core:2.0.16@jar" level="project" />
     <orderEntry type="library" name="Gradle: com.googlecode.mp4parser:isoparser:1.1.22@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-v4:22.2.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-v4-22.2.1" level="project" />
     <orderEntry type="library" name="Gradle: ch.qos.logback:logback-core:1.1.2@jar" level="project" />
     <orderEntry type="library" name="Gradle: org.slf4j:slf4j-api:1.7.21@jar" level="project" />
   </component>

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/PublishStreamManagerTest/PublishStreamManagerTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/PublishStreamManagerTest/PublishStreamManagerTest.java
@@ -77,7 +77,8 @@ public class PublishStreamManagerTest extends PublishTest {
                     //url format: https://{streammanagerhost}:{port}/streammanager/api/2.0/event/{scopeName}/{streamName}?action=broadcast
                     String port = TestContent.getFormattedPortSetting(TestContent.GetPropertyString("server_port"));
                     String version = TestContent.GetPropertyString("sm_version");
-                    String url = "http://" +
+                    String protocol = (port.isEmpty() || port.equals("443")) ? "https" : "http";
+                    String url = protocol + "://" +
                             TestContent.GetPropertyString("host") + port + "/streammanager/api/" + version + "/event/" +
                             TestContent.GetPropertyString("context") + "/" +
                             TestContent.GetPropertyString("stream1") + "?action=broadcast";

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/PublishStreamManagerTranscodeTest/PublishStreamManagerTranscodeTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/PublishStreamManagerTranscodeTest/PublishStreamManagerTranscodeTest.java
@@ -77,7 +77,8 @@ public class PublishStreamManagerTranscodeTest extends PublishTest {
                     //url format: https://{streammanagerhost}:{port}/streammanager/api/2.0/event/{scopeName}/{streamName}?action=broadca
                     String port = TestContent.getFormattedPortSetting(TestContent.GetPropertyString("server_port"));
                     String version = TestContent.GetPropertyString("sm_version");
-                    String url = "http://" +
+                    String protocol = (port.isEmpty() || port.equals("443")) ? "https" : "http";
+                    String url = protocol + "://" +
                             TestContent.GetPropertyString("host") + port + "/streammanager/api/" + version + "/event/" +
                             TestContent.GetPropertyString("context") + "/" +
                             TestContent.GetPropertyString("stream1") + "?action=broadcast&transcode=true";

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/SharedObjectTest/SharedObjectTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/SharedObjectTest/SharedObjectTest.java
@@ -214,8 +214,9 @@ public class SharedObjectTest extends PublishTest{
 
         addMessage("Retrieved list");
 
-        final String port = TestContent.getFormattedPortSetting(TestContent.GetPropertyString("server_port"));
-        final String urlStr = "http://" + TestContent.GetPropertyString("host") + port + "/" + TestContent.GetPropertyString("context") + "/streams.jsp";
+        String port = TestContent.getFormattedPortSetting(TestContent.GetPropertyString("server_port"));
+        String protocol = (port.isEmpty() || port.equals("443")) ? "https" : "http";
+        final String urlStr = protocol + "://" + TestContent.GetPropertyString("host") + port + "/" + TestContent.GetPropertyString("context") + "/streams.jsp";
 
         if(callThread != null) {
             callThread.interrupt();

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeCluster/SubscribeCluster.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeCluster/SubscribeCluster.java
@@ -78,7 +78,8 @@ public class SubscribeCluster extends SubscribeTest {
                 try{
                     HttpClient httpClient = new DefaultHttpClient();
                     String port = TestContent.getFormattedPortSetting(TestContent.GetPropertyString("server_port"));
-                    HttpResponse response = httpClient.execute(new HttpGet("http://" + TestContent.GetPropertyString("host") + port + "/cluster"));
+                    String protocol = (port.isEmpty() || port.equals("443")) ? "https" : "http";
+                    HttpResponse response = httpClient.execute(new HttpGet(protocol + "://" + TestContent.GetPropertyString("host") + port + "/cluster"));
                     StatusLine statusLine = response.getStatusLine();
                     if (statusLine.getStatusCode() == HttpStatus.SC_OK) {
                         ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeReconnectTest/SubscribeReconnectTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeReconnectTest/SubscribeReconnectTest.java
@@ -58,8 +58,9 @@ public class SubscribeReconnectTest extends SubscribeTest  {
 
     private void findStreams() {
 
-        final String port = TestContent.getFormattedPortSetting(TestContent.GetPropertyString("server_port"));
-        final String urlStr = "http://" + TestContent.GetPropertyString("host") + port + "/" + TestContent.GetPropertyString("context") + "/streams.jsp";
+        String port = TestContent.getFormattedPortSetting(TestContent.GetPropertyString("server_port"));
+        String protocol = (port.isEmpty() || port.equals("443")) ? "https" : "http";
+        final String urlStr = protocol + "://" + TestContent.GetPropertyString("host") + port + "/" + TestContent.GetPropertyString("context") + "/streams.jsp";
 
         if(callThread != null) {
             callThread.interrupt();

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeStreamManagerTest/SubscribeStreamManagerTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/SubscribeStreamManagerTest/SubscribeStreamManagerTest.java
@@ -76,7 +76,8 @@ public class SubscribeStreamManagerTest extends SubscribeTest {
                     //url format: https://{streammanagerhost}:{port}/streammanager/api/2.0/event/{scopeName}/{streamName}?action=subscribe
                     String port = TestContent.getFormattedPortSetting(TestContent.GetPropertyString("server_port"));
                     String version = TestContent.GetPropertyString("sm_version");
-                    String url = "http://" +
+                    String protocol = (port.isEmpty() || port.equals("443")) ? "https" : "http";
+                    String url = protocol + "://" +
                             TestContent.GetPropertyString("host") + port + "/streammanager/api/" + version + "/event/" +
                             TestContent.GetPropertyString("context") + "/" +
                             TestContent.GetPropertyString("stream1") + "?action=subscribe";

--- a/app/src/main/java/red5pro/org/testandroidproject/tests/TwoWayStreamManagerTest/TwoWayStreamManagerTest.java
+++ b/app/src/main/java/red5pro/org/testandroidproject/tests/TwoWayStreamManagerTest/TwoWayStreamManagerTest.java
@@ -98,8 +98,10 @@ public class TwoWayStreamManagerTest extends TwoWayTest {
 
                     //url format: https://{streammanagerhost}:{port}/streammanager/api/2.0/event/{scopeName}/{streamName}?action=broadcast
                     String port = TestContent.getFormattedPortSetting(TestContent.GetPropertyString("server_port"));
-                    String url = "http://" +
-                            TestContent.GetPropertyString("host") + port + "/streammanager/api/2.0/event/" +
+                    String version = TestContent.GetPropertyString("sm_version");
+                    String protocol = (port.isEmpty() || port.equals("443")) ? "https" : "http";
+                    String url = protocol + "://" +
+                            TestContent.GetPropertyString("host") + port + "/streammanager/api/" + version + "/event/" +
                             TestContent.GetPropertyString("context") + "/" + streamName + "?action=" + action;
 
                     HttpClient httpClient = new DefaultHttpClient();
@@ -204,7 +206,8 @@ public class TwoWayStreamManagerTest extends TwoWayTest {
                     try {
 
                         String port = TestContent.getFormattedPortSetting(TestContent.GetPropertyString("server_port"));
-                        String urlStr = "http://" + TestContent.GetPropertyString("host") + port + "/streammanager/api/2.0/event/list";
+                        String protocol = (port.isEmpty() || port.equals("443")) ? "https" : "http";
+                        String urlStr = protocol + "://" + TestContent.GetPropertyString("host") + port + "/streammanager/api/2.0/event/list";
 
                         URL url = new URL(urlStr);
                         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();

--- a/streaming-android.iml
+++ b/streaming-android.iml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="streaming-android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="java-gradle" name="Java-Gradle">
+      <configuration>
+        <option name="BUILD_FOLDER_PATH" value="$MODULE_DIR$/build" />
+        <option name="BUILDABLE" value="false" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
Previously, the `http` protocol was hardcoded and used in all server requests.
Now the tests determine the correct protocol (either `http` or `https`) based on the `server_port` configuration with `https` being used if the value is either an empty string or `443`.